### PR TITLE
Remove references to TypeMatcher from flutter

### DIFF
--- a/test/nested_test.dart
+++ b/test/nested_test.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart' hide TypeMatcher;
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:matcher/matcher.dart';
 import 'package:nested/nested.dart';
 
 import 'common.dart';


### PR DESCRIPTION
Removes references to TypeMatcher from Flutter
This deprecated API is being removed in https://github.com/flutter/flutter/pull/76331, and so all references should be removed to prevent breaking. :)